### PR TITLE
Loosen RDS version requirement

### DIFF
--- a/Module/Postgres/main.tf
+++ b/Module/Postgres/main.tf
@@ -112,7 +112,7 @@ resource "aws_db_instance" "valohai_roidb" {
   identifier = "dev-valohai-rds-roidb"
 
   engine                              = "postgres"
-  engine_version                      = "14.7"
+  engine_version                      = "14"
   instance_class                      = "db.m5.large"
   allocated_storage                   = 20
   storage_encrypted                   = true


### PR DESCRIPTION
We're allowing auto-upgrades and we're fine to use any version of 14, so lets loosen up the requirement here. So we don't end up in cases where the RDS version has been already upgraded, and the TF is pointing to an older version.