### PR TITLE
save tfstate in dynamoDB in an S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ terraform-docs markdown table --output-file README.md --output-mode inject .
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.26.0 |
 
 ## Modules
 
@@ -163,7 +165,9 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_dynamodb_table.dynamodb-terraform-state-lock](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ To empty & delete the S3 Bucket:
 You can then delete all the resources with:
 * Run `terraform destroy -var-file=variables.tfvars`
 
+## Terraform state
+
+By default the Terraform state is stored in a DynamoDB table in an S3 bucket. This setup is defined in the `backend.tf` and `dynamo.tf` files. You will need to update the correct S3 bucket name and the region to the `backend.tf` file. Note that AWS IAM user defined in the `variables.tfvars` needs to have the permissions listed in [the Terraform documentation for the S3 backend](https://developer.hashicorp.com/terraform/language/backend/s3#permissions-required).
+
+If you prefer storing the sate locally you can remove these files.
+
 ## Development
 
 Enforce Terraform styling guides with `terraform fmt -recursive`

--- a/backend.tf
+++ b/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    encrypt        = true
+    bucket         = "valohai-self-hosted-tf-state"
+    dynamodb_table = "terraform-state-lock-dynamo"
+    key            = "terraform.tfstate"
+    region         = "us-east-1"
+  }
+}

--- a/dynamo.tf
+++ b/dynamo.tf
@@ -1,0 +1,14 @@
+resource "aws_dynamodb_table" "dynamodb-terraform-state-lock" {
+  #checkov:skip=CKV_AWS_28:Ensure Dynamodb point in time recovery (backup) is enabled
+  #checkov:skip=CKV_AWS_119:Ensure DynamoDB Tables are encrypted using a KMS Customer Managed CMK
+  #checkov:skip=CKV2_AWS_16:Ensure that Auto Scaling is enabled on your DynamoDB tables
+  name           = "terraform-state-lock-dynamo"
+  hash_key       = "LockID"
+  read_capacity  = 20
+  write_capacity = 20
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}


### PR DESCRIPTION
* terraform.tfstate is saved in an S3 bucket defined in backend.tf under the account where the installation is done. 