### PR TITLE
add custom resource prefix instead of hardcoded values

### DIFF
--- a/Module/EC2/README.md
+++ b/Module/EC2/README.md
@@ -52,6 +52,7 @@ No modules.
 | <a name="input_organization"></a> [organization](#input\_organization) | Name of the organization in Valohai (e.g. MyOrg) | `string` | n/a | yes |
 | <a name="input_redis_url"></a> [redis\_url](#input\_redis\_url) | Address of the redis (node) that will host the job queue and short term logs. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | Region | `string` | n/a | yes |
+| <a name="input_resource_name_prefix"></a> [resource\_name\_prefix](#input\_resource\_name\_prefix) | Prefix for all named AWS resources | `string` | n/a | yes |
 | <a name="input_roi_subnet_id"></a> [roi\_subnet\_id](#input\_roi\_subnet\_id) | Subnet used for core Valohai web app and scaling services (Roi) | `string` | n/a | yes |
 | <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | Unique name for the S3 bucket that's used as the default output storage for Valohai | `string` | n/a | yes |
 | <a name="input_s3_kms_key"></a> [s3\_kms\_key](#input\_s3\_kms\_key) | ARN of the created S3 bucket | `string` | n/a | yes |

--- a/Module/EC2/config/user_data.sh
+++ b/Module/EC2/config/user_data.sh
@@ -19,7 +19,7 @@ sed -i "s|URL_BASE=|URL_BASE=${url_base}|" /etc/roi.config
 sed -i "s|AWS_REGION=|AWS_REGION=${region}|" /etc/roi.config
 sed -i "s|AWS_S3_BUCKET_NAME=|AWS_S3_BUCKET_NAME=${s3_bucket}|" /etc/roi.config
 sed -i "s|AWS_S3_KMS_KEY_ARN=|AWS_S3_KMS_KEY_ARN=${s3_kms_key}|" /etc/roi.config
-sed -i "s|AWS_S3_MULTIPART_UPLOAD_IAM_ROLE=|AWS_S3_MULTIPART_UPLOAD_IAM_ROLE=arn:aws:iam::${aws_account_id}:role/dev-valohai-iamr-multipart|" /etc/roi.config
+sed -i "s|AWS_S3_MULTIPART_UPLOAD_IAM_ROLE=|AWS_S3_MULTIPART_UPLOAD_IAM_ROLE=arn:aws:iam::${aws_account_id}:role/${resource_name_prefix}iamr-multipart|" /etc/roi.config
 sed -i "s|DEPLOY_REDIS_URL=|DEPLOY_REDIS_URL=redis://${redis_url}:6379|" /etc/roi.config
 sed -i "s|DATABASE_URL=|DATABASE_URL=psql://roi:${db_password}@${db_url}:5432/valohairoidb?sslmode=require\&sslcertmode=disable|" /etc/roi.config
 sed -i "s|PLATFORM_LONG_NAME=|PLATFORM_LONG_NAME=${environment_name}|" /etc/roi.config
@@ -54,5 +54,5 @@ sudo docker exec roi.service python manage.py roi_create_organization --name=${o
 # Create and save Valohai superadmin token used for the environments setup in SSM
 export VH_TOKEN=`echo $RANDOM | md5sum | head -c 32; echo;`
 sudo docker exec roi.service python manage.py shell -c "from roi.models import User;User.objects.filter(is_superuser=True).first().tokens.create(key='$VH_TOKEN')"
-aws ssm put-parameter --name "dev-valohai-app-token" --value "$VH_TOKEN" --type "SecureString" --tags "Key=Valohai,Value=1"
+aws ssm put-parameter --name "${resource_name_prefix}app-token" --value "$VH_TOKEN" --type "SecureString" --tags "Key=Valohai,Value=1"
 unset VH_TOKEN

--- a/Module/EC2/main.tf
+++ b/Module/EC2/main.tf
@@ -22,7 +22,7 @@ resource "aws_kms_key" "valohai_kms_key" {
         "Principal" : {
           "AWS" : [
             "arn:aws:iam::${var.aws_account_id}:root",
-            "arn:aws:iam::${var.aws_account_id}:role/dev-valohai-iamr-master",
+            "arn:aws:iam::${var.aws_account_id}:role/${var.resource_name_prefix}iamr-master",
           ]
         },
         "Action" : "kms:*",
@@ -42,7 +42,7 @@ resource "random_password" "repo_private_key" {
 }
 
 resource "aws_ssm_parameter" "repo_private_key" {
-  name        = "dev-valohai-ssm-repo"
+  name        = "${var.resource_name_prefix}ssm-repo"
   type        = "SecureString"
   description = "Secure repository key for Valohai"
   value       = random_password.repo_private_key.result
@@ -55,7 +55,7 @@ resource "random_password" "secret_key" {
 }
 
 resource "aws_ssm_parameter" "secret_key" {
-  name        = "dev-valohai-ssm-secret"
+  name        = "${var.resource_name_prefix}ssm-secret"
   type        = "SecureString"
   description = "Secure secret key for Valohai"
   value       = random_password.secret_key.result
@@ -68,7 +68,7 @@ resource "random_password" "jwt_key" {
 }
 
 resource "aws_ssm_parameter" "jwt_key" {
-  name        = "dev-valohai-ssm-jwt"
+  name        = "${var.resource_name_prefix}ssm-jwt"
   type        = "SecureString"
   description = "Secure jwt key for Valohai"
   value       = random_password.jwt_key.result
@@ -77,11 +77,11 @@ resource "aws_ssm_parameter" "jwt_key" {
 
 # Load public key
 resource "aws_key_pair" "valohai_roi_key" {
-  key_name   = "dev-valohai-key-valohai"
+  key_name   = "${var.resource_name_prefix}key-valohai"
   public_key = file(var.ec2_key)
 
   tags = {
-    Name = "dev-valohai-key-valohai",
+    Name = "${var.resource_name_prefix}key-valohai",
   }
 }
 
@@ -92,25 +92,26 @@ resource "aws_instance" "valohai_roi" {
   key_name               = aws_key_pair.valohai_roi_key.id
   vpc_security_group_ids = [aws_security_group.valohai_sg_roi.id]
   subnet_id              = var.roi_subnet_id
-  iam_instance_profile   = "dev-valohai-iami-master"
+  iam_instance_profile   = "${var.resource_name_prefix}iami-master"
   monitoring             = true
   ebs_optimized          = true
   user_data = templatefile("${path.module}/config/user_data.sh", {
-    repo_private_key = aws_ssm_parameter.repo_private_key.name
-    secret_key       = aws_ssm_parameter.secret_key.name
-    jwt_key          = aws_ssm_parameter.jwt_key.name
-    url_base         = var.domain
-    region           = var.region
-    s3_bucket        = var.s3_bucket_name
-    s3_kms_key       = var.s3_kms_key
-    aws_account_id   = var.aws_account_id
-    redis_url        = var.redis_url
-    db_password      = var.db_password
-    db_url           = var.db_url
-    environment_name = var.environment_name
-    module_path      = path.module
-    vpc_id           = var.vpc_id
-    organization     = var.organization
+    repo_private_key     = aws_ssm_parameter.repo_private_key.name
+    secret_key           = aws_ssm_parameter.secret_key.name
+    jwt_key              = aws_ssm_parameter.jwt_key.name
+    url_base             = var.domain
+    region               = var.region
+    s3_bucket            = var.s3_bucket_name
+    s3_kms_key           = var.s3_kms_key
+    aws_account_id       = var.aws_account_id
+    redis_url            = var.redis_url
+    db_password          = var.db_password
+    db_url               = var.db_url
+    environment_name     = var.environment_name
+    module_path          = path.module
+    vpc_id               = var.vpc_id
+    organization         = var.organization
+    resource_name_prefix = var.resource_name_prefix
   })
   user_data_replace_on_change = true
 
@@ -127,19 +128,19 @@ resource "aws_instance" "valohai_roi" {
   }
 
   tags = {
-    Name = "dev-valohai-ec2-roi",
+    Name = "${var.resource_name_prefix}ec2-roi",
   }
 
 }
 
 resource "aws_security_group" "valohai_sg_roi" {
-  name        = "dev-valohai-sg-roi"
+  name        = "${var.resource_name_prefix}sg-roi"
   description = "for Valohai Roi"
 
   vpc_id = var.vpc_id
 
   tags = {
-    Name = "dev-valohai-sg-roi",
+    Name = "${var.resource_name_prefix}sg-roi",
   }
 }
 

--- a/Module/EC2/variables.tf
+++ b/Module/EC2/variables.tf
@@ -78,3 +78,8 @@ variable "ami_id" {
   description = "AMI id from your Valohai contact"
   type        = string
 }
+
+variable "resource_name_prefix" {
+  description = "Prefix for all named AWS resources"
+  type        = string
+}

--- a/Module/IAM/Master-CrossAccount-Policy/README.md
+++ b/Module/IAM/Master-CrossAccount-Policy/README.md
@@ -25,6 +25,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_control_plane_resource_name_prefix"></a> [control\_plane\_resource\_name\_prefix](#input\_control\_plane\_resource\_name\_prefix) | resource\_name\_prefix used in the control plane account. The policy is attached to the control plane's master role, which uses this prefix. | `string` | n/a | yes |
+| <a name="input_resource_name_prefix"></a> [resource\_name\_prefix](#input\_resource\_name\_prefix) | resource\_name\_prefix of this (worker) deployment. Used for the worker account's master role that the policy grants AssumeRole on. | `string` | n/a | yes |
 | <a name="input_worker_account_id"></a> [worker\_account\_id](#input\_worker\_account\_id) | AWS Account ID of the worker account | `string` | n/a | yes |
 
 ## Outputs

--- a/Module/IAM/Master-CrossAccount-Policy/main.tf
+++ b/Module/IAM/Master-CrossAccount-Policy/main.tf
@@ -11,8 +11,8 @@ terraform {
 }
 
 resource "aws_iam_role_policy" "master_assume_worker_role" {
-  name = "dev-valohai-policy-assume-master-${var.worker_account_id}"
-  role = "dev-valohai-iamr-master" # Control plane master role
+  name = "${var.resource_name_prefix}policy-assume-master-${var.worker_account_id}"
+  role = "${var.control_plane_resource_name_prefix}iamr-master" # Control plane master role
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -21,7 +21,7 @@ resource "aws_iam_role_policy" "master_assume_worker_role" {
         Sid      = "AllowAssumeWorkerAccountMasterRole"
         Effect   = "Allow"
         Action   = "sts:AssumeRole"
-        Resource = "arn:aws:iam::${var.worker_account_id}:role/dev-valohai-iamr-master"
+        Resource = "arn:aws:iam::${var.worker_account_id}:role/${var.resource_name_prefix}iamr-master"
       }
     ]
   })

--- a/Module/IAM/Master-CrossAccount-Policy/variables.tf
+++ b/Module/IAM/Master-CrossAccount-Policy/variables.tf
@@ -2,3 +2,13 @@ variable "worker_account_id" {
   description = "AWS Account ID of the worker account"
   type        = string
 }
+
+variable "resource_name_prefix" {
+  description = "resource_name_prefix of this (worker) deployment. Used for the worker account's master role that the policy grants AssumeRole on."
+  type        = string
+}
+
+variable "control_plane_resource_name_prefix" {
+  description = "resource_name_prefix used in the control plane account. The policy is attached to the control plane's master role, which uses this prefix."
+  type        = string
+}

--- a/Module/IAM/Master/README.md
+++ b/Module/IAM/Master/README.md
@@ -31,6 +31,8 @@ No modules.
 | <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | AWS Account ID | `string` | n/a | yes |
 | <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | AWS profile for defining the provider | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS Region | `string` | n/a | yes |
+| <a name="input_control_plane_resource_name_prefix"></a> [control\_plane\_resource\_name\_prefix](#input\_control\_plane\_resource\_name\_prefix) | resource\_name\_prefix used in the control plane account (referenced by the cross-account trust policy when enable\_cross\_account\_trust is true) | `string` | n/a | yes |
+| <a name="input_resource_name_prefix"></a> [resource\_name\_prefix](#input\_resource\_name\_prefix) | Prefix for all named AWS resources | `string` | n/a | yes |
 | <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | Unique name for the S3 bucket that's used as the default output storage for Valohai | `string` | n/a | yes |
 | <a name="input_control_plane_account_id"></a> [control\_plane\_account\_id](#input\_control\_plane\_account\_id) | AWS Account ID of the control plane (only used when enable\_cross\_account\_trust is true) | `string` | `""` | no |
 | <a name="input_enable_cross_account_trust"></a> [enable\_cross\_account\_trust](#input\_enable\_cross\_account\_trust) | Enable trust relationship to allow control plane account to assume this role (set to true when creating worker account master role) | `bool` | `false` | no |

--- a/Module/IAM/Master/main.tf
+++ b/Module/IAM/Master/main.tf
@@ -17,7 +17,7 @@ locals {
     {
       Effect = "Allow"
       Principal = {
-        AWS = "arn:aws:iam::${var.control_plane_account_id}:role/dev-valohai-iamr-master"
+        AWS = "arn:aws:iam::${var.control_plane_account_id}:role/${var.control_plane_resource_name_prefix}iamr-master"
       }
       Action = "sts:AssumeRole"
     }
@@ -28,7 +28,7 @@ locals {
 }
 
 resource "aws_iam_role" "valohai_master_role" {
-  name = "dev-valohai-iamr-master"
+  name = "${var.resource_name_prefix}iamr-master"
 
   assume_role_policy = jsonencode({
     Version   = "2012-10-17"
@@ -37,12 +37,12 @@ resource "aws_iam_role" "valohai_master_role" {
 }
 
 resource "aws_iam_instance_profile" "valohai_master_profile" {
-  name = "dev-valohai-iami-master"
+  name = "${var.resource_name_prefix}iami-master"
   role = aws_iam_role.valohai_master_role.name
 }
 
 resource "aws_iam_role_policy" "valohai_master_policy" {
-  name = "dev-valohai-iamp-master"
+  name = "${var.resource_name_prefix}iamp-master"
   role = aws_iam_role.valohai_master_role.name
 
   policy = jsonencode({
@@ -106,7 +106,7 @@ resource "aws_iam_role_policy" "valohai_master_policy" {
         ],
         "Resource" : length(var.worker_role_names) > 0 ? [
           for name in var.worker_role_names : "arn:aws:iam::${var.aws_account_id}:role/${name}"
-      ] : ["arn:aws:iam::${var.aws_account_id}:role/dev-valohai-iamr-worker"] },
+      ] : ["arn:aws:iam::${var.aws_account_id}:role/${var.resource_name_prefix}iamr-worker"] },
       {
         "Sid" : "0",
         "Effect" : "Allow",

--- a/Module/IAM/Master/variables.tf
+++ b/Module/IAM/Master/variables.tf
@@ -34,3 +34,13 @@ variable "worker_role_names" {
   type        = list(string)
   default     = []
 }
+
+variable "resource_name_prefix" {
+  description = "Prefix for all named AWS resources"
+  type        = string
+}
+
+variable "control_plane_resource_name_prefix" {
+  description = "resource_name_prefix used in the control plane account (referenced by the cross-account trust policy when enable_cross_account_trust is true)"
+  type        = string
+}

--- a/Module/IAM/S3/README.md
+++ b/Module/IAM/S3/README.md
@@ -28,6 +28,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | AWS Account ID | `string` | n/a | yes |
+| <a name="input_resource_name_prefix"></a> [resource\_name\_prefix](#input\_resource\_name\_prefix) | Prefix for all named AWS resources | `string` | n/a | yes |
 | <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | Unique name for the S3 bucket that's used as the default output storage for Valohai | `string` | n/a | yes |
 
 ## Outputs

--- a/Module/IAM/S3/main.tf
+++ b/Module/IAM/S3/main.tf
@@ -10,7 +10,7 @@ terraform {
 }
 
 resource "aws_iam_role" "valohai_data_multipart" {
-  name        = "dev-valohai-iamr-multipart"
+  name        = "${var.resource_name_prefix}iamr-multipart"
   description = "Allows users to save files over 5GB from their executions"
 
   assume_role_policy = jsonencode({
@@ -19,7 +19,7 @@ resource "aws_iam_role" "valohai_data_multipart" {
       {
         "Effect" : "Allow",
         "Principal" : {
-          "AWS" : "arn:aws:iam::${var.aws_account_id}:role/dev-valohai-iamr-master"
+          "AWS" : "arn:aws:iam::${var.aws_account_id}:role/${var.resource_name_prefix}iamr-master"
         },
         "Action" : "sts:AssumeRole"
       }
@@ -28,7 +28,7 @@ resource "aws_iam_role" "valohai_data_multipart" {
 }
 
 resource "aws_iam_role_policy" "valohai_multipart_policy" {
-  name = "dev-valohai-iamp-multipart"
+  name = "${var.resource_name_prefix}iamp-multipart"
   role = aws_iam_role.valohai_data_multipart.name
 
   policy = jsonencode({

--- a/Module/IAM/S3/variables.tf
+++ b/Module/IAM/S3/variables.tf
@@ -7,3 +7,8 @@ variable "s3_bucket_name" {
   description = "Unique name for the S3 bucket that's used as the default output storage for Valohai"
   type        = string
 }
+
+variable "resource_name_prefix" {
+  description = "Prefix for all named AWS resources"
+  type        = string
+}

--- a/Module/LB/README.md
+++ b/Module/LB/README.md
@@ -38,6 +38,7 @@ No modules.
 | <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | AWS Account ID | `string` | n/a | yes |
 | <a name="input_certificate_arn"></a> [certificate\_arn](#input\_certificate\_arn) | Certificate ARN | `string` | n/a | yes |
 | <a name="input_lb_subnet_ids"></a> [lb\_subnet\_ids](#input\_lb\_subnet\_ids) | Subnet used for core Valohai web app and scaling services (Roi) | `list(string)` | n/a | yes |
+| <a name="input_resource_name_prefix"></a> [resource\_name\_prefix](#input\_resource\_name\_prefix) | Prefix for all named AWS resources | `string` | n/a | yes |
 | <a name="input_s3_logs_name"></a> [s3\_logs\_name](#input\_s3\_logs\_name) | Unique name for the S3 bucket that's used as the default log storage | `string` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC Id used for ELB | `string` | n/a | yes |
 

--- a/Module/LB/main.tf
+++ b/Module/LB/main.tf
@@ -12,7 +12,7 @@ terraform {
 resource "aws_lb" "valohai_lb" {
   #checkov:skip=CKV2_AWS_28:Ensure public facing ALB are protected by WAF
   #checkov:skip=CKV2_AWS_20:Allow using HTTP only on ALB for sample purposes
-  name                       = "dev-valohai-alb-valohai"
+  name                       = "${var.resource_name_prefix}alb-valohai"
   load_balancer_type         = "application"
   internal                   = false
   subnets                    = var.lb_subnet_ids
@@ -75,7 +75,7 @@ resource "aws_lb_listener" "http" {
 
 resource "aws_security_group" "valohai_sg_lb" {
   #checkov:skip=CKV_AWS_260:Allow port 80 for example purposes
-  name        = "dev-valohai-sg-alb"
+  name        = "${var.resource_name_prefix}sg-alb"
   description = "for Valohai ELB"
 
   vpc_id = var.vpc_id

--- a/Module/LB/variables.tf
+++ b/Module/LB/variables.tf
@@ -22,3 +22,8 @@ variable "s3_logs_name" {
   description = "Unique name for the S3 bucket that's used as the default log storage"
   type        = string
 }
+
+variable "resource_name_prefix" {
+  description = "Prefix for all named AWS resources"
+  type        = string
+}

--- a/Module/Postgres/README.md
+++ b/Module/Postgres/README.md
@@ -38,6 +38,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | AWS Account ID | `string` | n/a | yes |
 | <a name="input_db_subnet_ids"></a> [db\_subnet\_ids](#input\_db\_subnet\_ids) | A list of (private) subnets for the Postgresql database. Minimum two subnets. | `list(string)` | n/a | yes |
+| <a name="input_resource_name_prefix"></a> [resource\_name\_prefix](#input\_resource\_name\_prefix) | Prefix for all named AWS resources | `string` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC Id where the Valohai Postgresql database will be placed in. | `string` | n/a | yes |
 
 ## Outputs

--- a/Module/Postgres/main.tf
+++ b/Module/Postgres/main.tf
@@ -29,8 +29,8 @@ resource "aws_kms_key" "valohai_db_kms_key" {
         "Principal" : {
           "AWS" : [
             "arn:aws:iam::${var.aws_account_id}:root",
-            "arn:aws:iam::${var.aws_account_id}:role/dev-valohai-iamr-master",
-            "arn:aws:iam::${var.aws_account_id}:role/dev-valohai-iamr-rdsmonitor",
+            "arn:aws:iam::${var.aws_account_id}:role/${var.resource_name_prefix}iamr-master",
+            "arn:aws:iam::${var.aws_account_id}:role/${var.resource_name_prefix}iamr-rdsmonitor",
           ]
         },
         "Action" : "kms:*",
@@ -42,7 +42,7 @@ resource "aws_kms_key" "valohai_db_kms_key" {
 
 resource "aws_kms_alias" "valohai_kms_alias" {
   target_key_id = aws_kms_key.valohai_db_kms_key.key_id
-  name          = "alias/dev-valohai-kmsa-valohaidb"
+  name          = "alias/${var.resource_name_prefix}kmsa-valohaidb"
 }
 
 resource "random_password" "password" {
@@ -51,7 +51,7 @@ resource "random_password" "password" {
 }
 
 resource "aws_ssm_parameter" "db_password" {
-  name        = "dev-valohai-ssm-dbpassword"
+  name        = "${var.resource_name_prefix}ssm-dbpassword"
   type        = "SecureString"
   description = "Password for Valohai roidb"
   value       = random_password.password.result
@@ -59,13 +59,13 @@ resource "aws_ssm_parameter" "db_password" {
 }
 
 resource "aws_db_subnet_group" "valohai_roidb_subnet" {
-  name       = "dev-valohai-rds-subnet"
+  name       = "${var.resource_name_prefix}rds-subnet"
   subnet_ids = var.db_subnet_ids
 
 }
 
 resource "aws_security_group" "valohai_roidb_sg" {
-  name        = "dev-valohai-rds-db"
+  name        = "${var.resource_name_prefix}rds-db"
   description = "Valohai RDS security group"
   vpc_id      = var.vpc_id
 
@@ -79,7 +79,7 @@ resource "aws_security_group" "valohai_roidb_sg" {
 }
 
 resource "aws_db_parameter_group" "valohai_roidb" {
-  name   = "dev-valohai-rdspg-db"
+  name   = "${var.resource_name_prefix}rdspg-db"
   family = "postgres16"
 
   parameter {
@@ -94,7 +94,7 @@ resource "aws_db_parameter_group" "valohai_roidb" {
 }
 
 resource "aws_iam_role" "valohai_rds_monitoring_role" {
-  name = "dev-valohai-iamr-rdsmonitor"
+  name = "${var.resource_name_prefix}iamr-rdsmonitor"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -112,12 +112,12 @@ resource "aws_iam_role" "valohai_rds_monitoring_role" {
   managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"]
 
   tags = {
-    Name = "dev-valohai-iamr-rdsmonitor"
+    Name = "${var.resource_name_prefix}iamr-rdsmonitor"
   }
 }
 
 resource "aws_db_instance" "valohai_roidb" {
-  identifier = "dev-valohai-rds-roidb"
+  identifier = "${var.resource_name_prefix}rds-roidb"
 
   engine         = "postgres"
   engine_version = "16"

--- a/Module/Postgres/variables.tf
+++ b/Module/Postgres/variables.tf
@@ -12,3 +12,8 @@ variable "db_subnet_ids" {
   description = "A list of (private) subnets for the Postgresql database. Minimum two subnets."
   type        = list(string)
 }
+
+variable "resource_name_prefix" {
+  description = "Prefix for all named AWS resources"
+  type        = string
+}

--- a/Module/Redis/README.md
+++ b/Module/Redis/README.md
@@ -29,6 +29,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cache_subnet_ids"></a> [cache\_subnet\_ids](#input\_cache\_subnet\_ids) | A list of (private) subnets for the Redis Elasticache used to store short-term logs and the job queue. | `list(string)` | n/a | yes |
+| <a name="input_resource_name_prefix"></a> [resource\_name\_prefix](#input\_resource\_name\_prefix) | Prefix for all named AWS resources | `string` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC Id used for ELB | `string` | n/a | yes |
 
 ## Outputs

--- a/Module/Redis/main.tf
+++ b/Module/Redis/main.tf
@@ -14,13 +14,13 @@ data "aws_vpc" "valohai_vpc" {
 }
 
 resource "aws_elasticache_subnet_group" "valohai_queue_subnet" {
-  name       = "dev-valohai-elcsg-queue"
+  name       = "${var.resource_name_prefix}elcsg-queue"
   subnet_ids = var.cache_subnet_ids
 
 }
 
 resource "aws_elasticache_cluster" "valohai_queue" {
-  cluster_id = "dev-valohai-elc-queue"
+  cluster_id = "${var.resource_name_prefix}elc-queue"
   engine     = "redis"
   #node_type                = "cache.m4.xlarge"
   node_type                = "cache.t3.small" # dev
@@ -34,7 +34,7 @@ resource "aws_elasticache_cluster" "valohai_queue" {
 }
 
 resource "aws_security_group" "valohai_sg_queue" {
-  name        = "dev-valohai-sg-queue"
+  name        = "${var.resource_name_prefix}sg-queue"
   description = "for Valohai Queue"
 
   vpc_id = var.vpc_id
@@ -48,6 +48,6 @@ resource "aws_security_group" "valohai_sg_queue" {
   }
 
   tags = {
-    Name = "dev-valohai-sg-queue",
+    Name = "${var.resource_name_prefix}sg-queue",
   }
 }

--- a/Module/Redis/variables.tf
+++ b/Module/Redis/variables.tf
@@ -7,3 +7,8 @@ variable "cache_subnet_ids" {
   description = "A list of (private) subnets for the Redis Elasticache used to store short-term logs and the job queue."
   type        = list(string)
 }
+
+variable "resource_name_prefix" {
+  description = "Prefix for all named AWS resources"
+  type        = string
+}

--- a/Module/S3/README.md
+++ b/Module/S3/README.md
@@ -34,6 +34,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | AWS Account ID | `string` | n/a | yes |
 | <a name="input_domain"></a> [domain](#input\_domain) | Address that will be used to access the service | `string` | n/a | yes |
+| <a name="input_resource_name_prefix"></a> [resource\_name\_prefix](#input\_resource\_name\_prefix) | Prefix for all named AWS resources | `string` | n/a | yes |
 | <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | Unique name for the S3 bucket that's used as the default output storage for Valohai | `string` | n/a | yes |
 | <a name="input_s3_logs_name"></a> [s3\_logs\_name](#input\_s3\_logs\_name) | Unique name for the S3 bucket that's used as the default log storage | `string` | n/a | yes |
 

--- a/Module/S3/main.tf
+++ b/Module/S3/main.tf
@@ -22,8 +22,8 @@ resource "aws_kms_key" "valohai_data_kms_key" {
         "Principal" : {
           "AWS" : [
             "arn:aws:iam::${var.aws_account_id}:root",
-            "arn:aws:iam::${var.aws_account_id}:role/dev-valohai-iamr-master",
-            "arn:aws:iam::${var.aws_account_id}:role/dev-valohai-iamr-multipart"
+            "arn:aws:iam::${var.aws_account_id}:role/${var.resource_name_prefix}iamr-master",
+            "arn:aws:iam::${var.aws_account_id}:role/${var.resource_name_prefix}iamr-multipart"
           ]
         },
         "Action" : "kms:*",

--- a/Module/S3/variables.tf
+++ b/Module/S3/variables.tf
@@ -17,3 +17,8 @@ variable "s3_logs_name" {
   description = "Unique name for the S3 bucket that's used as the default log storage"
   type        = string
 }
+
+variable "resource_name_prefix" {
+  description = "Prefix for all named AWS resources"
+  type        = string
+}

--- a/Module/Workers/Security-groups/README.md
+++ b/Module/Workers/Security-groups/README.md
@@ -28,6 +28,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_ec2_key"></a> [ec2\_key](#input\_ec2\_key) | Location of the ssh key pub file for worker instances | `string` | n/a | yes |
+| <a name="input_resource_name_prefix"></a> [resource\_name\_prefix](#input\_resource\_name\_prefix) | Prefix for all named AWS resources | `string` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC Id used for the workers | `string` | n/a | yes |
 | <a name="input_create_roi_ingress_rule"></a> [create\_roi\_ingress\_rule](#input\_create\_roi\_ingress\_rule) | Whether to create ingress rule on ROI security group (only if workers are in same account) | `bool` | `false` | no |
 | <a name="input_roi_sg_id"></a> [roi\_sg\_id](#input\_roi\_sg\_id) | Valohai Worker security group | `string` | `"50"` | no |

--- a/Module/Workers/Security-groups/main.tf
+++ b/Module/Workers/Security-groups/main.tf
@@ -1,17 +1,17 @@
 # Load public key for worker instances
 resource "aws_key_pair" "valohai_worker_key" {
-  key_name   = "dev-valohai-key-workers"
+  key_name   = "${var.resource_name_prefix}key-workers"
   public_key = file(var.ec2_key)
 
   tags = {
-    Name = "dev-valohai-key-workers",
+    Name = "${var.resource_name_prefix}key-workers",
   }
 }
 
 # Create worker security group
 resource "aws_security_group" "valohai_sg_workers" {
   #checkov:skip=CKV2_AWS_5:Ensure security groups are attached to another resource
-  name        = "dev-valohai-sg-workers"
+  name        = "${var.resource_name_prefix}sg-workers"
   description = "for Valohai workers"
 
   vpc_id = var.vpc_id
@@ -25,7 +25,7 @@ resource "aws_security_group" "valohai_sg_workers" {
   }
 
   tags = {
-    Name = "dev-valohai-sg-workers",
+    Name = "${var.resource_name_prefix}sg-workers",
   }
 }
 

--- a/Module/Workers/Security-groups/variables.tf
+++ b/Module/Workers/Security-groups/variables.tf
@@ -19,3 +19,8 @@ variable "ec2_key" {
   description = "Location of the ssh key pub file for worker instances"
   type        = string
 }
+
+variable "resource_name_prefix" {
+  description = "Prefix for all named AWS resources"
+  type        = string
+}

--- a/Module/Workers/Valohai-environments-SecurityGroup/README.md
+++ b/Module/Workers/Valohai-environments-SecurityGroup/README.md
@@ -25,6 +25,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_resource_name_prefix"></a> [resource\_name\_prefix](#input\_resource\_name\_prefix) | Prefix for all named AWS resources | `string` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID where the security group will be created | `string` | n/a | yes |
 
 ## Outputs

--- a/Module/Workers/Valohai-environments-SecurityGroup/main.tf
+++ b/Module/Workers/Valohai-environments-SecurityGroup/main.tf
@@ -9,7 +9,7 @@ terraform {
 # Security group for the environment setup machine
 resource "aws_security_group" "valohai_sg_env_setup" {
   #checkov:skip=CKV2_AWS_5: "Ensure that Security Groups are attached to another resource"
-  name        = "dev-valohai-sg-env-setup"
+  name        = "${var.resource_name_prefix}sg-env-setup"
   description = "for Valohai Environmet Setup"
 
   vpc_id = var.vpc_id
@@ -23,6 +23,6 @@ resource "aws_security_group" "valohai_sg_env_setup" {
   }
 
   tags = {
-    Name = "dev-valohai-sg-env-setup",
+    Name = "${var.resource_name_prefix}sg-env-setup",
   }
 }

--- a/Module/Workers/Valohai-environments-SecurityGroup/variables.tf
+++ b/Module/Workers/Valohai-environments-SecurityGroup/variables.tf
@@ -2,3 +2,8 @@ variable "vpc_id" {
   description = "VPC ID where the security group will be created"
   type        = string
 }
+
+variable "resource_name_prefix" {
+  description = "Prefix for all named AWS resources"
+  type        = string
+}

--- a/Module/Workers/Valohai-environments/README.md
+++ b/Module/Workers/Valohai-environments/README.md
@@ -31,9 +31,11 @@ No modules.
 | <a name="input_aws_instance_types"></a> [aws\_instance\_types](#input\_aws\_instance\_types) | A list of AWS instance types that should be created | `list(string)` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS Region | `string` | n/a | yes |
 | <a name="input_aws_spot_instance_types"></a> [aws\_spot\_instance\_types](#input\_aws\_spot\_instance\_types) | A list of AWS spot instance types that should be created | `list(string)` | n/a | yes |
+| <a name="input_control_plane_resource_name_prefix"></a> [control\_plane\_resource\_name\_prefix](#input\_control\_plane\_resource\_name\_prefix) | resource\_name\_prefix used in the control plane account. The setup machine runs in the control plane account, so its key pair, instance profile and app-token SSM parameter use this prefix. | `string` | n/a | yes |
 | <a name="input_domain"></a> [domain](#input\_domain) | Address that will be used to access the service | `string` | n/a | yes |
 | <a name="input_env_setup_sg_id"></a> [env\_setup\_sg\_id](#input\_env\_setup\_sg\_id) | Security group ID for the environment setup machine | `string` | n/a | yes |
 | <a name="input_redis_url"></a> [redis\_url](#input\_redis\_url) | Address of the redis (node) that will host the job queue and short term logs. | `string` | n/a | yes |
+| <a name="input_resource_name_prefix"></a> [resource\_name\_prefix](#input\_resource\_name\_prefix) | Prefix for all named AWS resources | `string` | n/a | yes |
 | <a name="input_roi_subnet_id"></a> [roi\_subnet\_id](#input\_roi\_subnet\_id) | Subnet used for the temporary setup machine under the control plane account | `string` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC Id used for the workers | `string` | n/a | yes |
 | <a name="input_aws_worker_account_id"></a> [aws\_worker\_account\_id](#input\_aws\_worker\_account\_id) | AWS Account ID for workers | `string` | `""` | no |

--- a/Module/Workers/Valohai-environments/config/user_data.sh
+++ b/Module/Workers/Valohai-environments/config/user_data.sh
@@ -7,7 +7,7 @@ sudo apt-get -o DPkg::Lock::Timeout=-1 install jq -y
 # Set up the environments
 echo "${file("${module_path}/config/prep_template.yaml")}" > /home/ubuntu/prep_template.yaml
 
-export VH_TOKEN=`aws ssm get-parameter --name 'dev-valohai-app-token' --with-decryption | sed -n 's|.*"Value": *"\([^"]*\)".*|\1|p'`
+export VH_TOKEN=`aws ssm get-parameter --name ${control_plane_resource_name_prefix}app-token --with-decryption | sed -n 's|.*"Value": *"\([^"]*\)".*|\1|p'`
 sed -i "s|valohai-token: ''|valohai-token: '$VH_TOKEN'|" /home/ubuntu/prep_template.yaml
 unset VH_TOKEN
 
@@ -17,9 +17,9 @@ sed -i "s|asg-name-prefix: ''|asg-name-prefix: '${env_asg_prefix}'|" /home/ubunt
 sed -i "s|queue-name-prefix: ''|queue-name-prefix: '${env_queue_prefix}'|" /home/ubuntu/prep_template.yaml
 sed -i "s|region: ''|region: '${region}'|" /home/ubuntu/prep_template.yaml
 sed -i "s|redis-url: ''|redis-url: 'redis://${redis_url}:6379'|" /home/ubuntu/prep_template.yaml
-sed -i "s|security-group-name: ''|security-group-name: 'dev-valohai-sg-workers'|" /home/ubuntu/prep_template.yaml
+sed -i "s|security-group-name: ''|security-group-name: '${resource_name_prefix}sg-workers'|" /home/ubuntu/prep_template.yaml
 sed -i "s|vpc-id: ''|vpc-id: '${worker_vpc_id}'|" /home/ubuntu/prep_template.yaml
-sed -i "s|key-pair-name: ''|key-pair-name: 'dev-valohai-key-workers'|" /home/ubuntu/prep_template.yaml
+sed -i "s|key-pair-name: ''|key-pair-name: '${resource_name_prefix}key-workers'|" /home/ubuntu/prep_template.yaml
 echo "  ${aws_instance_types}" >> /home/ubuntu/prep_template.yaml
 echo "  ${aws_spot_instance_types}" >> /home/ubuntu/prep_template.yaml
 
@@ -30,7 +30,7 @@ if [ "${aws_account_id}" != "${aws_worker_account_id}" ]; then
   echo "Setting up cross-account access to worker account..."
 
   # Assume worker account role
-  WORKER_ROLE_ARN="arn:aws:iam::${aws_worker_account_id}:role/dev-valohai-iamr-master"
+  WORKER_ROLE_ARN="arn:aws:iam::${aws_worker_account_id}:role/${resource_name_prefix}iamr-master"
 
   CREDS=$(aws sts assume-role \
     --role-arn "$WORKER_ROLE_ARN" \

--- a/Module/Workers/Valohai-environments/main.tf
+++ b/Module/Workers/Valohai-environments/main.tf
@@ -10,26 +10,28 @@ terraform {
 resource "aws_instance" "valohai_environments_setup" {
   ami                    = var.ami_id
   instance_type          = "t3.medium"
-  key_name               = "dev-valohai-key-valohai"
+  key_name               = "${var.control_plane_resource_name_prefix}key-valohai"
   vpc_security_group_ids = [var.env_setup_sg_id]
   subnet_id              = var.roi_subnet_id
-  iam_instance_profile   = "dev-valohai-iami-master"
+  iam_instance_profile   = "${var.control_plane_resource_name_prefix}iami-master"
   monitoring             = true
   ebs_optimized          = true
   user_data = templatefile("${path.module}/config/user_data.sh", {
-    url_base                = var.domain
-    region                  = var.aws_region
-    aws_account_id          = var.aws_account_id
-    aws_worker_account_id   = var.aws_worker_account_id
-    redis_url               = var.redis_url
-    module_path             = path.module
-    worker_vpc_id           = var.vpc_id
-    organization            = var.env_owner_id
-    env_name_prefix         = var.env_name_prefix
-    env_asg_prefix          = var.env_asg_prefix
-    env_queue_prefix        = var.env_queue_prefix
-    aws_instance_types      = indent(2, yamlencode(var.aws_instance_types))
-    aws_spot_instance_types = var.add_spot_instances ? indent(2, yamlencode(formatlist("%s.spot", var.aws_spot_instance_types))) : ""
+    url_base                           = var.domain
+    region                             = var.aws_region
+    aws_account_id                     = var.aws_account_id
+    aws_worker_account_id              = var.aws_worker_account_id
+    redis_url                          = var.redis_url
+    module_path                        = path.module
+    resource_name_prefix               = var.resource_name_prefix
+    control_plane_resource_name_prefix = var.control_plane_resource_name_prefix
+    worker_vpc_id                      = var.vpc_id
+    organization                       = var.env_owner_id
+    env_name_prefix                    = var.env_name_prefix
+    env_asg_prefix                     = var.env_asg_prefix
+    env_queue_prefix                   = var.env_queue_prefix
+    aws_instance_types                 = indent(2, yamlencode(var.aws_instance_types))
+    aws_spot_instance_types            = var.add_spot_instances ? indent(2, yamlencode(formatlist("%s.spot", var.aws_spot_instance_types))) : ""
   })
   user_data_replace_on_change = true
 
@@ -46,7 +48,7 @@ resource "aws_instance" "valohai_environments_setup" {
   }
 
   tags = {
-    Name = "dev-valohai-ec2-environment-setup",
+    Name = "${var.resource_name_prefix}ec2-environment-setup",
   }
 
   lifecycle {

--- a/Module/Workers/Valohai-environments/variables.tf
+++ b/Module/Workers/Valohai-environments/variables.tf
@@ -82,3 +82,13 @@ variable "aws_spot_instance_types" {
   description = "A list of AWS spot instance types that should be created"
   type        = list(string)
 }
+
+variable "resource_name_prefix" {
+  description = "Prefix for all named AWS resources"
+  type        = string
+}
+
+variable "control_plane_resource_name_prefix" {
+  description = "resource_name_prefix used in the control plane account. The setup machine runs in the control plane account, so its key pair, instance profile and app-token SSM parameter use this prefix."
+  type        = string
+}

--- a/main.tf
+++ b/main.tf
@@ -33,16 +33,25 @@ provider "aws" {
   }
 }
 
+locals {
+  # The resource_name_prefix used in the control plane account, for the worker deployment's
+  # cross-account references. Falls back to this deployment's resource_name_prefix when both
+  # accounts share a prefix (single-account / same-prefix setups).
+  control_plane_resource_name_prefix = var.control_plane_resource_name_prefix != "" ? var.control_plane_resource_name_prefix : var.resource_name_prefix
+}
+
 module "IAM_Master" {
   source = "./Module/IAM/Master"
 
-  aws_profile                = var.aws_profile
-  aws_region                 = var.aws_region
-  aws_account_id             = var.install_workers && !var.workers_in_control_plane ? var.aws_worker_account_id : var.aws_account_id
-  s3_bucket_name             = var.s3_bucket_name
-  enable_cross_account_trust = var.install_workers && !var.workers_in_control_plane
-  control_plane_account_id   = var.aws_account_id # Control plane account ID
-  worker_role_names          = [for k, m in module.IAM_Workers : m.worker_role_name]
+  aws_profile                        = var.aws_profile
+  aws_region                         = var.aws_region
+  aws_account_id                     = var.install_workers && !var.workers_in_control_plane ? var.aws_worker_account_id : var.aws_account_id
+  resource_name_prefix               = var.resource_name_prefix
+  control_plane_resource_name_prefix = local.control_plane_resource_name_prefix
+  s3_bucket_name                     = var.s3_bucket_name
+  enable_cross_account_trust         = var.install_workers && !var.workers_in_control_plane
+  control_plane_account_id           = var.aws_account_id # Control plane account ID
+  worker_role_names                  = [for k, m in module.IAM_Workers : m.worker_role_name]
 
   depends_on = [module.IAM_Workers]
 }
@@ -58,7 +67,9 @@ module "IAM_Master_CrossAccount_Policy" {
 
   count = var.install_workers && !var.workers_in_control_plane ? 1 : 0
 
-  worker_account_id = var.aws_worker_account_id
+  worker_account_id                  = var.aws_worker_account_id
+  resource_name_prefix               = var.resource_name_prefix
+  control_plane_resource_name_prefix = local.control_plane_resource_name_prefix
 }
 
 module "IAM_Workers" {
@@ -77,8 +88,9 @@ module "IAM_S3" {
 
   count = var.install_control_plane ? 1 : 0
 
-  aws_account_id = var.aws_account_id
-  s3_bucket_name = var.s3_bucket_name
+  aws_account_id       = var.aws_account_id
+  resource_name_prefix = var.resource_name_prefix
+  s3_bucket_name       = var.s3_bucket_name
 
   depends_on = [
     module.IAM_Master
@@ -94,9 +106,10 @@ module "Database" {
 
   count = var.install_control_plane ? 1 : 0
 
-  aws_account_id = var.aws_account_id
-  vpc_id         = var.vpc_id
-  db_subnet_ids  = var.db_subnet_ids
+  aws_account_id       = var.aws_account_id
+  resource_name_prefix = var.resource_name_prefix
+  vpc_id               = var.vpc_id
+  db_subnet_ids        = var.db_subnet_ids
 }
 
 module "Redis" {
@@ -108,8 +121,9 @@ module "Redis" {
 
   count = var.install_control_plane ? 1 : 0
 
-  vpc_id           = var.vpc_id
-  cache_subnet_ids = var.db_subnet_ids
+  vpc_id               = var.vpc_id
+  cache_subnet_ids     = var.db_subnet_ids
+  resource_name_prefix = var.resource_name_prefix
 }
 
 module "S3" {
@@ -121,10 +135,11 @@ module "S3" {
 
   count = var.install_control_plane ? 1 : 0
 
-  domain         = var.domain
-  aws_account_id = var.aws_account_id
-  s3_bucket_name = var.s3_bucket_name
-  s3_logs_name   = var.s3_logs_name
+  domain               = var.domain
+  aws_account_id       = var.aws_account_id
+  resource_name_prefix = var.resource_name_prefix
+  s3_bucket_name       = var.s3_bucket_name
+  s3_logs_name         = var.s3_logs_name
 
   depends_on = [module.IAM_S3]
 }
@@ -138,11 +153,12 @@ module "LB" {
 
   count = var.install_control_plane ? 1 : 0
 
-  aws_account_id  = var.aws_account_id
-  vpc_id          = var.vpc_id
-  lb_subnet_ids   = var.lb_subnet_ids
-  certificate_arn = var.certificate_arn
-  s3_logs_name    = var.s3_logs_name
+  aws_account_id       = var.aws_account_id
+  resource_name_prefix = var.resource_name_prefix
+  vpc_id               = var.vpc_id
+  lb_subnet_ids        = var.lb_subnet_ids
+  certificate_arn      = var.certificate_arn
+  s3_logs_name         = var.s3_logs_name
 }
 
 module "EC2" {
@@ -154,23 +170,24 @@ module "EC2" {
 
   count = var.install_control_plane ? 1 : 0
 
-  aws_account_id     = var.aws_account_id
-  ec2_key            = var.ec2_key
-  region             = var.aws_region
-  vpc_id             = var.vpc_id
-  roi_subnet_id      = var.roi_subnet_id
-  lb_target_group_id = module.LB[0].target_group_id
-  lb_sg              = module.LB[0].security_group_id
-  s3_bucket_name     = var.s3_bucket_name
-  s3_kms_key         = module.S3[0].kms_key
-  environment_name   = var.environment_name
-  organization       = var.organization
-  db_url             = module.Database[0].database_url
-  db_password        = module.Database[0].database_password
-  redis_url          = module.Redis[0].redis_url
-  domain             = var.domain
-  ami_id             = var.ami_id
-  depends_on         = [module.Database, module.IAM_Master, module.Redis, module.S3, module.LB]
+  aws_account_id       = var.aws_account_id
+  resource_name_prefix = var.resource_name_prefix
+  ec2_key              = var.ec2_key
+  region               = var.aws_region
+  vpc_id               = var.vpc_id
+  roi_subnet_id        = var.roi_subnet_id
+  lb_target_group_id   = module.LB[0].target_group_id
+  lb_sg                = module.LB[0].security_group_id
+  s3_bucket_name       = var.s3_bucket_name
+  s3_kms_key           = module.S3[0].kms_key
+  environment_name     = var.environment_name
+  organization         = var.organization
+  db_url               = module.Database[0].database_url
+  db_password          = module.Database[0].database_password
+  redis_url            = module.Redis[0].redis_url
+  domain               = var.domain
+  ami_id               = var.ami_id
+  depends_on           = [module.Database, module.IAM_Master, module.Redis, module.S3, module.LB]
 }
 
 
@@ -256,6 +273,7 @@ module "Workers_Security-groups" {
   vpc_id                  = var.worker_vpc_id
   roi_sg_id               = var.install_control_plane ? module.EC2[0].roi_security_group_id : ""
   ec2_key                 = var.ec2_key
+  resource_name_prefix    = var.resource_name_prefix
   create_roi_ingress_rule = var.workers_in_control_plane
 }
 
@@ -268,7 +286,8 @@ module "Workers_Valohai-environments-SecurityGroup" {
 
   count = var.install_control_plane ? 1 : 0
 
-  vpc_id = var.vpc_id
+  vpc_id               = var.vpc_id
+  resource_name_prefix = var.resource_name_prefix
 }
 
 module "Workers_Valohai-environments" {
@@ -280,21 +299,23 @@ module "Workers_Valohai-environments" {
 
   for_each = var.install_workers ? var.environments : {}
 
-  aws_region              = var.aws_region
-  aws_account_id          = var.aws_account_id
-  aws_worker_account_id   = var.aws_worker_account_id
-  vpc_id                  = var.worker_vpc_id
-  roi_subnet_id           = var.roi_subnet_id
-  env_setup_sg_id         = var.workers_in_control_plane ? module.Workers_Valohai-environments-SecurityGroup[0].security_group_id : ""
-  redis_url               = each.value.redis_url != "" ? each.value.redis_url : length(module.Redis) > 0 ? module.Redis[0].redis_url : var.redis_url
-  domain                  = var.domain
-  ami_id                  = var.ami_id
-  env_owner_id            = each.value.env_owner_id
-  env_name_prefix         = each.value.env_name_prefix
-  env_asg_prefix          = each.value.env_asg_prefix
-  env_queue_prefix        = each.value.env_queue_prefix
-  aws_instance_types      = each.value.aws_instance_types
-  aws_spot_instance_types = each.value.aws_spot_instance_types
-  add_spot_instances      = each.value.add_spot_instances
-  depends_on              = [module.Redis, module.EC2, module.Workers_Valohai-environments-SecurityGroup]
+  aws_region                         = var.aws_region
+  aws_account_id                     = var.aws_account_id
+  resource_name_prefix               = var.resource_name_prefix
+  control_plane_resource_name_prefix = local.control_plane_resource_name_prefix
+  aws_worker_account_id              = var.aws_worker_account_id
+  vpc_id                             = var.worker_vpc_id
+  roi_subnet_id                      = var.roi_subnet_id
+  env_setup_sg_id                    = var.workers_in_control_plane ? module.Workers_Valohai-environments-SecurityGroup[0].security_group_id : "sg-080c6695450015af1"
+  redis_url                          = each.value.redis_url != "" ? each.value.redis_url : length(module.Redis) > 0 ? module.Redis[0].redis_url : var.redis_url
+  domain                             = var.domain
+  ami_id                             = var.ami_id
+  env_owner_id                       = each.value.env_owner_id
+  env_name_prefix                    = each.value.env_name_prefix
+  env_asg_prefix                     = each.value.env_asg_prefix
+  env_queue_prefix                   = each.value.env_queue_prefix
+  aws_instance_types                 = each.value.aws_instance_types
+  aws_spot_instance_types            = each.value.aws_spot_instance_types
+  add_spot_instances                 = each.value.add_spot_instances
+  depends_on                         = [module.Redis, module.EC2, module.Workers_Valohai-environments-SecurityGroup]
 }

--- a/main.tf
+++ b/main.tf
@@ -306,7 +306,7 @@ module "Workers_Valohai-environments" {
   aws_worker_account_id              = var.aws_worker_account_id
   vpc_id                             = var.worker_vpc_id
   roi_subnet_id                      = var.roi_subnet_id
-  env_setup_sg_id                    = var.workers_in_control_plane ? module.Workers_Valohai-environments-SecurityGroup[0].security_group_id : "sg-080c6695450015af1"
+  env_setup_sg_id                    = var.workers_in_control_plane ? module.Workers_Valohai-environments-SecurityGroup[0].security_group_id : ""
   redis_url                          = each.value.redis_url != "" ? each.value.redis_url : length(module.Redis) > 0 ? module.Redis[0].redis_url : var.redis_url
   domain                             = var.domain
   ami_id                             = var.ami_id

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,18 @@ variable "aws_account_id" {
   type        = string
 }
 
+variable "resource_name_prefix" {
+  description = "Prefix for all named AWS resources"
+  type        = string
+  default     = "dev-valohai-"
+}
+
+variable "control_plane_resource_name_prefix" {
+  description = "resource_name_prefix used in the control plane account. Only needed in a cross-account worker deployment, where worker resources reference the control plane's master role, key pair, instance profile and app-token. Leave empty to reuse resource_name_prefix (same prefix in both accounts)."
+  type        = string
+  default     = ""
+}
+
 variable "aws_worker_account_id" {
   description = "AWS Account ID for workers (set this when deploying workers to different account)"
   type        = string

--- a/variables.tfvars
+++ b/variables.tfvars
@@ -24,10 +24,15 @@ organization     = ""
 ami_id           = "" # AMI id from your Valohai contact
 
 # Define what will be installed
-install_control_plane    = true  # True for single account installations, false for cross-account worker installation
-install_workers          = false # false for initial app installation
-workers_in_control_plane = true  # Set to true if workers are in the same AWS account as ROI
-redis_url                = ""    # Global fallback Redis URL from the control plane deployment
+install_control_plane    = true           # True for single account installations, false for cross-account worker installation
+install_workers          = false          # false for initial app installation
+workers_in_control_plane = true           # Set to true if workers are in the same AWS account as ROI
+redis_url                = ""             # Global fallback Redis URL from the control plane deployment
+resource_name_prefix     = "dev-valohai-" # General prefix for resource names
+# Only needed for cross-account worker deployments: the resource_name_prefix of the control plane account.
+# Leave empty/unset to reuse resource_name_prefix (same prefix in both accounts).
+# control_plane_resource_name_prefix = ""
+
 
 # Worker setup
 environments = {


### PR DESCRIPTION
- Added variables `resource_name_prefix` and optional `control_plane_resource_name_prefix` for managing the resource naming. 
- `control_plane_resource_name_prefix` is used only in multiaccount setups, otherwise it will default to `resource_name_prefix`