### PR TITLE
add worker subnets from tfvars file to prep template

### DIFF
--- a/Module/Workers/Valohai-environments/README.md
+++ b/Module/Workers/Valohai-environments/README.md
@@ -38,6 +38,7 @@ No modules.
 | <a name="input_resource_name_prefix"></a> [resource\_name\_prefix](#input\_resource\_name\_prefix) | Prefix for all named AWS resources | `string` | n/a | yes |
 | <a name="input_roi_subnet_id"></a> [roi\_subnet\_id](#input\_roi\_subnet\_id) | Subnet used for the temporary setup machine under the control plane account | `string` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC Id used for the workers | `string` | n/a | yes |
+| <a name="input_worker_subnet_ids"></a> [worker\_subnet\_ids](#input\_worker\_subnet\_ids) | A list of subnets where Valohai workers can be placed | `list(string)` | n/a | yes |
 | <a name="input_aws_worker_account_id"></a> [aws\_worker\_account\_id](#input\_aws\_worker\_account\_id) | AWS Account ID for workers | `string` | `""` | no |
 | <a name="input_env_asg_prefix"></a> [env\_asg\_prefix](#input\_env\_asg\_prefix) | Prefix for ASG names in Valohai environments | `string` | `"dev-valohai-worker-"` | no |
 | <a name="input_env_name_prefix"></a> [env\_name\_prefix](#input\_env\_name\_prefix) | Prefix for Valohai environment names | `string` | `""` | no |

--- a/Module/Workers/Valohai-environments/config/prep_template.yaml
+++ b/Module/Workers/Valohai-environments/config/prep_template.yaml
@@ -17,7 +17,5 @@ aws:
   roi-redis-url: '' # starts with redis://
   security-group-name: '' # add your security group name
   vpc-id: '' # add with your vpc-id
-  vpc-subnets:
-    - 'valohai-subnet-*' # replace with how your subnets are named
   key-pair-name: '' # add your EC2 key pair name (same as for the Valohai master instance)
   instance-types:

--- a/Module/Workers/Valohai-environments/config/user_data.sh
+++ b/Module/Workers/Valohai-environments/config/user_data.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Failsafe to shut down the machine in case the script fails, leaves some time for debugging
+shutdown -h +120
+
 set -xeuo pipefail
 sudo apt-get -o DPkg::Lock::Timeout=-1 update || true
 sudo apt-get -o DPkg::Lock::Timeout=-1 install jq -y
@@ -22,6 +25,8 @@ sed -i "s|vpc-id: ''|vpc-id: '${worker_vpc_id}'|" /home/ubuntu/prep_template.yam
 sed -i "s|key-pair-name: ''|key-pair-name: '${resource_name_prefix}key-workers'|" /home/ubuntu/prep_template.yaml
 echo "  ${aws_instance_types}" >> /home/ubuntu/prep_template.yaml
 echo "  ${aws_spot_instance_types}" >> /home/ubuntu/prep_template.yaml
+echo "  vpc-subnets:" >> /home/ubuntu/prep_template.yaml
+echo "  ${worker_subnet_ids}" >> /home/ubuntu/prep_template.yaml
 
 sed -i "s|valohai-env-owner-id: ''|valohai-env-owner-id: '${organization}'|" /home/ubuntu/prep_template.yaml
 
@@ -52,5 +57,5 @@ fi
 # Run the prep script
 su ubuntu -c "python3 -m prep --config-yaml /home/ubuntu/prep_template.yaml aws"
 
-# Shutdown
+# Shutdown, overrides the failsafe from the beginning of the script
 shutdown -h now

--- a/Module/Workers/Valohai-environments/main.tf
+++ b/Module/Workers/Valohai-environments/main.tf
@@ -8,14 +8,15 @@ terraform {
 
 # Temporary machine for setting up environment in Valohai
 resource "aws_instance" "valohai_environments_setup" {
-  ami                    = var.ami_id
-  instance_type          = "t3.medium"
-  key_name               = "${var.control_plane_resource_name_prefix}key-valohai"
-  vpc_security_group_ids = [var.env_setup_sg_id]
-  subnet_id              = var.roi_subnet_id
-  iam_instance_profile   = "${var.control_plane_resource_name_prefix}iami-master"
-  monitoring             = true
-  ebs_optimized          = true
+  ami                                  = var.ami_id
+  instance_type                        = "t3.medium"
+  key_name                             = "${var.control_plane_resource_name_prefix}key-valohai"
+  vpc_security_group_ids               = [var.env_setup_sg_id]
+  subnet_id                            = var.roi_subnet_id
+  iam_instance_profile                 = "${var.control_plane_resource_name_prefix}iami-master"
+  monitoring                           = true
+  ebs_optimized                        = true
+  instance_initiated_shutdown_behavior = "terminate"
   user_data = templatefile("${path.module}/config/user_data.sh", {
     url_base                           = var.domain
     region                             = var.aws_region
@@ -30,6 +31,7 @@ resource "aws_instance" "valohai_environments_setup" {
     env_name_prefix                    = var.env_name_prefix
     env_asg_prefix                     = var.env_asg_prefix
     env_queue_prefix                   = var.env_queue_prefix
+    worker_subnet_ids                  = indent(2, yamlencode(var.worker_subnet_ids))
     aws_instance_types                 = indent(2, yamlencode(var.aws_instance_types))
     aws_spot_instance_types            = var.add_spot_instances ? indent(2, yamlencode(formatlist("%s.spot", var.aws_spot_instance_types))) : ""
   })

--- a/Module/Workers/Valohai-environments/variables.tf
+++ b/Module/Workers/Valohai-environments/variables.tf
@@ -29,6 +29,11 @@ variable "roi_subnet_id" {
   type        = string
 }
 
+variable "worker_subnet_ids" {
+  description = "A list of subnets where Valohai workers can be placed"
+  type        = list(string)
+}
+
 variable "redis_url" {
   description = "Address of the redis (node) that will host the job queue and short term logs."
   type        = string

--- a/main.tf
+++ b/main.tf
@@ -306,6 +306,7 @@ module "Workers_Valohai-environments" {
   aws_worker_account_id              = var.aws_worker_account_id
   vpc_id                             = var.worker_vpc_id
   roi_subnet_id                      = var.roi_subnet_id
+  worker_subnet_ids                  = var.worker_subnet_ids
   env_setup_sg_id                    = var.workers_in_control_plane ? module.Workers_Valohai-environments-SecurityGroup[0].security_group_id : ""
   redis_url                          = each.value.redis_url != "" ? each.value.redis_url : length(module.Redis) > 0 ? module.Redis[0].redis_url : var.redis_url
   domain                             = var.domain


### PR DESCRIPTION
- Instead of hardcoding the subnet names, use the ids provided in the tfvars file in the prep template as well. 
- Added also better shut down behavior for the environment setup machine:
  - Instead of stopping the machine, it will be terminated
  - If the user_data script fails, the machine will be kept alive for 2 hours and then shut down automatically